### PR TITLE
Correct the reference to the Git repo

### DIFF
--- a/cmdg.rb
+++ b/cmdg.rb
@@ -1,7 +1,7 @@
 class Cmdg < Formula
   desc "Gmail CLI - Copyright Thomas Habets thomas@habets.se 2019"
   homepage "https://github.com/ThomasHabets/cmdg"
-  head "https://github.com/ThomasHabets/cmdg"
+  head "https://github.com/ThomasHabets/cmdg.git"
   version "1.3"
   depends_on "go"
   def install


### PR DESCRIPTION
I believe this will fix issue #2 linked below. I was getting a similar
error, and applying this patch fixed the problem.

Without this patch, the brew command downloads the HTML page of the URL
from GitHub.

https://github.com/cutzenfriend/homebrew-cmdg/issues/2